### PR TITLE
Add cube flip animation on launch

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -15,6 +15,7 @@ html, body {
   inset: 0;
   background: #111;               /* фон лаунчера */
   overflow: hidden;
+  perspective: 800px;            /* для 3D-поворота кубиков */
 }
 
 /* внутренний интерфейс */
@@ -56,10 +57,23 @@ html, body {
 .status { margin-top:.5rem; color:#aaa; font-size:.9rem; }
 .piece {
   position: absolute;
+  transform-style: preserve-3d;
   animation-fill-mode: forwards;
-  animation-name: fadePiece;
+  animation-name: flipPiece;
 }
 
-@keyframes fadePiece {
-  to { opacity: 0; transform: scale(0); }
+.piece .face {
+  position: absolute;
+  inset: 0;
+  background-size: cover;
+  backface-visibility: hidden;
+}
+
+.piece .back {
+  transform: rotateY(180deg);
+}
+
+@keyframes flipPiece {
+  from { transform: rotateY(0deg); }
+  to   { transform: rotateY(180deg); }
 }

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -4,6 +4,8 @@ import html2canvas from 'html2canvas';
 import './App.css';
 
 const API = 'http://89.104.67.130:4000';
+// Путь к изображению, на которое будут «перевёрнуты» кубики
+const TARGET_IMG = 'assets/flip-target.png';
 
 export default function App() {
   const [username, setUsername] = useState('');
@@ -55,6 +57,19 @@ export default function App() {
     const cellH = height / ROWS;
     const ctx = canvas.getContext('2d')!;
 
+    // Подготовка изображения назначения
+    const targetImg = await new Promise<HTMLImageElement>((res, rej) => {
+      const img = new Image();
+      img.src = TARGET_IMG;
+      img.onload = () => res(img);
+      img.onerror = rej;
+    });
+    const targetCanvas = document.createElement('canvas');
+    targetCanvas.width = width;
+    targetCanvas.height = height;
+    const tCtx = targetCanvas.getContext('2d')!;
+    tCtx.drawImage(targetImg, 0, 0, width, height);
+
     // Случайный порядок индексов
     const order = Array.from({ length: TOTAL }, (_, i) => i).sort(
       () => Math.random() - 0.5
@@ -64,12 +79,20 @@ export default function App() {
     const newPieces: React.ReactElement[] = order.map((idx, n) => {
       const r = Math.floor(idx / COLS);
       const c = idx % COLS;
-      const slice = ctx.getImageData(c * cellW, r * cellH, cellW, cellH);
-      const pieceCanvas = document.createElement('canvas');
-      pieceCanvas.width = cellW;
-      pieceCanvas.height = cellH;
-      pieceCanvas.getContext('2d')!.putImageData(slice, 0, 0);
-      const url = pieceCanvas.toDataURL();
+
+      const frontSlice = ctx.getImageData(c * cellW, r * cellH, cellW, cellH);
+      const frontCanvas = document.createElement('canvas');
+      frontCanvas.width = cellW;
+      frontCanvas.height = cellH;
+      frontCanvas.getContext('2d')!.putImageData(frontSlice, 0, 0);
+      const frontUrl = frontCanvas.toDataURL();
+
+      const backSlice = tCtx.getImageData(c * cellW, r * cellH, cellW, cellH);
+      const backCanvas = document.createElement('canvas');
+      backCanvas.width = cellW;
+      backCanvas.height = cellH;
+      backCanvas.getContext('2d')!.putImageData(backSlice, 0, 0);
+      const backUrl = backCanvas.toDataURL();
 
       return (
         <div
@@ -80,11 +103,13 @@ export default function App() {
             height: cellH,
             left:   c * cellW,
             top:    r * cellH,
-            backgroundImage: `url(${url})`,
             animationDelay:    `${n * DELAY}ms`,
             animationDuration: `${DURA}ms`,
           }}
-        />
+        >
+          <div className="face front" style={{ backgroundImage: `url(${frontUrl})` }} />
+          <div className="face back"  style={{ backgroundImage: `url(${backUrl})` }} />
+        </div>
       );
     });
 


### PR DESCRIPTION
## Summary
- implement 3D cube flip when launching the game
- allow specifying path to the target image

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68486f0a8cc08333a6ace8353172e4e7