### PR TITLE
Add cube flip animation on launch

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -15,6 +15,7 @@ html, body {
   inset: 0;
   background: #111;               /* фон лаунчера */
   overflow: hidden;
+  perspective: 800px;            /* для 3D-поворота кубиков */
 }
 
 /* внутренний интерфейс */
@@ -29,25 +30,6 @@ html, body {
   z-index: 1;
 }
 
-/* маска-кубики */
-.cube-mask {
-  position: absolute;
-  inset: 0;
-  display: grid;
-  grid-gap: 1px;
-  pointer-events: none;
-  z-index: 2;
-}
-
-.cube-mask > div {
-  background: #111;               /* тот же цвет, что фон окна */
-  animation-fill-mode: forwards;
-  animation-name: cubeFade;
-}
-
-@keyframes cubeFade {
-  to { opacity: 0; transform: scale(0); }
-}
 
 /* простые стили полей / кнопок */
 .input       { padding: .5rem;  border-radius: 4px; border: 1px solid #444; width: 220px; margin-bottom: 1rem; }
@@ -56,10 +38,23 @@ html, body {
 .status { margin-top:.5rem; color:#aaa; font-size:.9rem; }
 .piece {
   position: absolute;
+  transform-style: preserve-3d;
   animation-fill-mode: forwards;
-  animation-name: fadePiece;
+  animation-name: flipPiece;
 }
 
-@keyframes fadePiece {
-  to { opacity: 0; transform: scale(0); }
+.piece .face {
+  position: absolute;
+  inset: 0;
+  background-size: cover;
+  backface-visibility: hidden;
+}
+
+.piece .back {
+  transform: rotateY(180deg);
+}
+
+@keyframes flipPiece {
+  from { transform: rotateY(0deg); }
+  to   { transform: rotateY(180deg); }
 }


### PR DESCRIPTION
## Summary
- implement 3D cube flip when launching the game
- allow specifying path to the target image
- fix cube flip by rendering slices via background positioning

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration)*
- `npm run build` *(fails: Missing script 'build')*

------
https://chatgpt.com/codex/tasks/task_e_68486f0a8cc08333a6ace8353172e4e7